### PR TITLE
Replace age slider with birth date entry

### DIFF
--- a/src/components/app/AgeEntry.module.css
+++ b/src/components/app/AgeEntry.module.css
@@ -35,91 +35,44 @@
   margin-bottom: var(--space-2xl);
 }
 
-/* ─── Slider ──────────────────────────────────────────────────────── */
-.sliderContainer {
+/* ─── Selects ─────────────────────────────────────────────────────── */
+.selectGroup {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-lg);
+  gap: var(--space-md);
   width: 100%;
-  max-width: 480px;
-  margin-bottom: var(--space-2xl);
+  max-width: 400px;
+  margin-bottom: var(--space-lg);
 }
 
-.slider {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--color-border);
-  outline: none;
+.select {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-family);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: 10px;
   cursor: pointer;
-  transition: background var(--transition-fast);
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23999' stroke-width='2' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+  transition: border-color var(--transition-fast),
+              box-shadow var(--transition-fast);
+}
 
-  /* Firefox track */
-  &::-moz-range-track {
-    height: 6px;
-    border-radius: 3px;
-    background: var(--color-border);
-    border: none;
-  }
+.select:hover {
+  border-color: var(--color-accent);
+}
 
-  /* Firefox progress fill */
-  &::-moz-range-progress {
-    height: 6px;
-    border-radius: 3px;
-    background: var(--color-accent);
-  }
-
-  /* Webkit thumb */
-  &::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    background: var(--color-accent);
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(74, 144, 217, 0.4);
-    transition: background var(--transition-fast),
-                transform var(--transition-fast),
-                box-shadow var(--transition-fast);
-  }
-
-  &::-webkit-slider-thumb:hover {
-    background: var(--color-accent-hover);
-    transform: scale(1.15);
-    box-shadow: 0 4px 14px rgba(74, 144, 217, 0.5);
-  }
-
-  &::-webkit-slider-thumb:active {
-    transform: scale(1.05);
-  }
-
-  /* Firefox thumb */
-  &::-moz-range-thumb {
-    width: 28px;
-    height: 28px;
-    border: none;
-    border-radius: 50%;
-    background: var(--color-accent);
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(74, 144, 217, 0.4);
-    transition: background var(--transition-fast),
-                transform var(--transition-fast);
-  }
-
-  &::-moz-range-thumb:hover {
-    background: var(--color-accent-hover);
-    transform: scale(1.15);
-  }
-
-  &:focus-visible {
-    outline: 3px solid var(--color-accent);
-    outline-offset: 4px;
-    border-radius: 3px;
-  }
+.select:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(74, 144, 217, 0.2);
 }
 
 /* ─── Age display ─────────────────────────────────────────────────── */
@@ -130,6 +83,15 @@
   text-align: center;
   letter-spacing: -0.01em;
   min-height: 1.4em;
+  margin-bottom: var(--space-sm);
+}
+
+/* ─── Hint ────────────────────────────────────────────────────────── */
+.hint {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  text-align: center;
+  margin-bottom: var(--space-md);
 }
 
 /* ─── Start button ────────────────────────────────────────────────── */
@@ -148,17 +110,19 @@
   cursor: pointer;
   transition: background var(--transition-fast),
               transform var(--transition-fast),
-              box-shadow var(--transition-fast);
+              box-shadow var(--transition-fast),
+              opacity var(--transition-fast);
   box-shadow: 0 4px 16px rgba(74, 144, 217, 0.35);
+  margin-top: var(--space-md);
 }
 
-.startButton:hover {
+.startButton:hover:not(:disabled) {
   background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 6px 20px rgba(74, 144, 217, 0.45);
 }
 
-.startButton:active {
+.startButton:active:not(:disabled) {
   transform: translateY(0);
   box-shadow: 0 2px 8px rgba(74, 144, 217, 0.3);
 }
@@ -166,6 +130,11 @@
 .startButton:focus-visible {
   outline: 3px solid var(--color-accent);
   outline-offset: 3px;
+}
+
+.startButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* ─── Responsive ──────────────────────────────────────────────────── */
@@ -181,8 +150,8 @@
     margin-bottom: var(--space-xl);
   }
 
-  .sliderContainer {
-    margin-bottom: var(--space-xl);
+  .selectGroup {
+    margin-bottom: var(--space-md);
   }
 
   .startButton {

--- a/src/components/app/AgeEntry.tsx
+++ b/src/components/app/AgeEntry.tsx
@@ -1,38 +1,104 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import styles from './AgeEntry.module.css'
 
-interface AgeEntryProps {
-  onSubmit: (ageMonths: number) => void
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+]
+
+const MIN_AGE_MONTHS = 12
+const MAX_AGE_MONTHS = 60
+
+function computeAgeMonths(birthMonth: number, birthYear: number): number {
+  const now = new Date()
+  return (now.getFullYear() - birthYear) * 12 + (now.getMonth() + 1 - birthMonth)
 }
 
-export function AgeEntry({ onSubmit }: AgeEntryProps) {
-  const [age, setAge] = useState(24)
+function formatAge(months: number): string {
+  if (months < 24) return `${months} months old`
+  const y = Math.floor(months / 12)
+  const m = months % 12
+  if (m === 0) return `${y} year${y > 1 ? 's' : ''} old`
+  return `${y} year${y > 1 ? 's' : ''}, ${m} month${m !== 1 ? 's' : ''} old`
+}
 
-  const ageLabel = age < 24
-    ? `${age} months`
-    : `${Math.floor(age / 12)} year${Math.floor(age / 12) > 1 ? 's' : ''}, ${age % 12} month${age % 12 !== 1 ? 's' : ''}`
+interface AgeEntryProps {
+  onSubmit: (ageMonths: number, birthMonth: number, birthYear: number) => void
+  initialBirthMonth?: number
+  initialBirthYear?: number
+}
+
+export function AgeEntry({ onSubmit, initialBirthMonth, initialBirthYear }: AgeEntryProps) {
+  const now = new Date()
+  const currentYear = now.getFullYear()
+  const currentMonth = now.getMonth() + 1
+
+  const defaultMonth = initialBirthMonth ?? currentMonth
+  const defaultYear = initialBirthYear ?? (currentYear - 2)
+
+  const [birthMonth, setBirthMonth] = useState(defaultMonth)
+  const [birthYear, setBirthYear] = useState(defaultYear)
+
+  const years = useMemo(() => {
+    const result: number[] = []
+    for (let y = currentYear; y >= currentYear - 6; y--) {
+      result.push(y)
+    }
+    return result
+  }, [currentYear])
+
+  const ageMonths = computeAgeMonths(birthMonth, birthYear)
+  const inRange = ageMonths >= MIN_AGE_MONTHS && ageMonths <= MAX_AGE_MONTHS
+  const isFuture = ageMonths < 0
 
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>How old is your child?</h1>
+      <h1 className={styles.title}>When was your child born?</h1>
       <p className={styles.subtitle}>
         We'll match words and sounds to their developmental stage.
       </p>
 
-      <div className={styles.sliderContainer}>
-        <input
-          type="range"
-          min={12}
-          max={60}
-          value={age}
-          onChange={(e) => setAge(Number(e.target.value))}
-          className={styles.slider}
-          aria-label="Child's age in months"
-        />
-        <div className={styles.ageDisplay}>{ageLabel}</div>
+      <div className={styles.selectGroup}>
+        <select
+          value={birthMonth}
+          onChange={(e) => setBirthMonth(Number(e.target.value))}
+          className={styles.select}
+          aria-label="Birth month"
+        >
+          {MONTH_NAMES.map((name, i) => (
+            <option key={i + 1} value={i + 1}>{name}</option>
+          ))}
+        </select>
+
+        <select
+          value={birthYear}
+          onChange={(e) => setBirthYear(Number(e.target.value))}
+          className={styles.select}
+          aria-label="Birth year"
+        >
+          {years.map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
       </div>
 
-      <button className={styles.startButton} onClick={() => onSubmit(age)}>
+      <div className={styles.ageDisplay}>
+        {isFuture
+          ? "That's in the future!"
+          : formatAge(ageMonths)}
+      </div>
+
+      {!isFuture && !inRange && (
+        <p className={styles.hint}>
+          This app is designed for children 1–5 years old.
+        </p>
+      )}
+
+      <button
+        className={styles.startButton}
+        disabled={!inRange}
+        onClick={() => onSubmit(ageMonths, birthMonth, birthYear)}
+      >
         Start practicing
       </button>
     </div>

--- a/src/components/app/FilterPanel.module.css
+++ b/src/components/app/FilterPanel.module.css
@@ -169,42 +169,54 @@
   transition: color var(--transition-fast);
 }
 
-/* ─── Tier buttons ────────────────────────────────────────────────── */
-.tierButtons {
+/* ─── Tier list ──────────────────────────────────────────────────── */
+.tierList {
   display: flex;
+  flex-direction: column;
   gap: var(--space-sm);
-  flex-wrap: wrap;
 }
 
-.tierButton {
-  padding: var(--space-xs) var(--space-md);
+.tierItem {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: var(--space-sm) var(--space-md);
   border: 2px solid var(--color-border);
-  border-radius: 20px;
+  border-radius: 10px;
   background: var(--color-surface);
-  color: var(--color-text-muted);
   font-family: var(--font-family);
-  font-size: var(--font-size-small);
-  font-weight: 600;
   cursor: pointer;
+  text-align: left;
   transition: border-color var(--transition-fast),
-              background var(--transition-fast),
-              color var(--transition-fast);
+              background var(--transition-fast);
 }
 
-.tierButton:hover {
+.tierItem:hover {
   border-color: var(--color-accent);
-  color: var(--color-accent);
 }
 
-.tierButtonActive {
+.tierItemActive {
   border-color: var(--color-accent);
   background: var(--color-accent-light);
-  color: var(--color-accent);
 }
 
-.tierButton:focus-visible {
+.tierItem:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+}
+
+.tierLabel {
+  font-size: var(--font-size-small);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.tierDescription {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  line-height: 1.3;
 }
 
 /* ─── Shuffle toggle ──────────────────────────────────────────────── */

--- a/src/components/app/FilterPanel.tsx
+++ b/src/components/app/FilterPanel.tsx
@@ -1,4 +1,5 @@
 import type { Tier } from '~/data/types'
+import { ALL_CATEGORIES } from '~/engine/cardOrdering'
 import styles from './FilterPanel.module.css'
 
 interface FilterPanelProps {
@@ -12,11 +13,10 @@ interface FilterPanelProps {
   onShuffleToggle: () => void
 }
 
-const ALL_CATEGORIES = ['actions', 'animals', 'body', 'colors', 'describing', 'food', 'house', 'people', 'vehicles']
-const TIER_OPTIONS: { value: Tier; label: string }[] = [
-  { value: 1, label: 'Produce' },
-  { value: 2, label: 'Guided' },
-  { value: 3, label: 'Listen' },
+const TIER_OPTIONS: { value: Tier; label: string; description: string }[] = [
+  { value: 1, label: 'Produce', description: 'Sounds your child has mastered — encourage saying the word' },
+  { value: 2, label: 'Guided', description: 'Emerging sounds — model the word clearly, celebrate attempts' },
+  { value: 3, label: 'Listen', description: 'Future sounds — just expose, no pressure to repeat' },
 ]
 
 export function FilterPanel({
@@ -44,7 +44,7 @@ export function FilterPanel({
               <label key={cat} className={styles.checkboxLabel}>
                 <input
                   type="checkbox"
-                  checked={selectedCategories.length === 0 || selectedCategories.includes(cat)}
+                  checked={selectedCategories.includes(cat)}
                   onChange={() => onCategoryToggle(cat)}
                   className={styles.checkbox}
                 />
@@ -55,19 +55,18 @@ export function FilterPanel({
         </div>
 
         <div className={styles.section}>
-          <h3 className={styles.sectionTitle}>Tier</h3>
-          <div className={styles.tierButtons}>
+          <h3 className={styles.sectionTitle}>Practice mode</h3>
+          <div className={styles.tierList}>
             {TIER_OPTIONS.map(opt => (
               <button
                 key={opt.value}
-                className={`${styles.tierButton} ${
-                  selectedTiers.length === 0 || selectedTiers.includes(opt.value)
-                    ? styles.tierButtonActive
-                    : ''
+                className={`${styles.tierItem} ${
+                  selectedTiers.includes(opt.value) ? styles.tierItemActive : ''
                 }`}
                 onClick={() => onTierToggle(opt.value)}
               >
-                {opt.label}
+                <span className={styles.tierLabel}>{opt.label}</span>
+                <span className={styles.tierDescription}>{opt.description}</span>
               </button>
             ))}
           </div>

--- a/src/engine/cardOrdering.ts
+++ b/src/engine/cardOrdering.ts
@@ -11,6 +11,8 @@ for (const [i, group] of staticRhymeGroups.entries()) {
   }
 }
 
+export const ALL_CATEGORIES = ['actions', 'animals', 'body', 'colors', 'describing', 'food', 'house', 'people', 'vehicles'] as const
+
 export interface FilterState {
   categories: string[]
   tiers: Tier[]
@@ -21,8 +23,8 @@ export interface FilterState {
 }
 
 export const DEFAULT_FILTERS: FilterState = {
-  categories: [],
-  tiers: [],
+  categories: [...ALL_CATEGORIES],
+  tiers: [1, 2],
   targetSound: null,
   wordTypes: [],
   rhymeMode: false,

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -13,17 +13,44 @@ export const Route = createFileRoute('/app')({
   component: AppRoute,
 })
 
-const STORAGE_KEY_AGE = 'phoneme-trainer-age'
+const STORAGE_KEY_BIRTH = 'phoneme-trainer-birth'
 const STORAGE_KEY_OVERRIDES = 'phoneme-trainer-overrides'
 
-function loadAge(): number | null {
-  if (typeof window === 'undefined') return null
-  const stored = localStorage.getItem(STORAGE_KEY_AGE)
-  return stored ? Number(stored) : null
+interface BirthDate {
+  month: number
+  year: number
 }
 
-function saveAge(age: number) {
-  localStorage.setItem(STORAGE_KEY_AGE, String(age))
+function loadBirth(): BirthDate | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY_BIRTH)
+    if (!stored) return null
+    const parsed = JSON.parse(stored)
+    if (parsed && typeof parsed.month === 'number' && typeof parsed.year === 'number') {
+      return parsed as BirthDate
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function saveBirth(month: number, year: number) {
+  localStorage.setItem(STORAGE_KEY_BIRTH, JSON.stringify({ month, year }))
+}
+
+function computeAgeMonths(birth: BirthDate): number {
+  const now = new Date()
+  return (now.getFullYear() - birth.year) * 12 + (now.getMonth() + 1 - birth.month)
+}
+
+function formatAgeShort(months: number): string {
+  const y = Math.floor(months / 12)
+  const m = months % 12
+  if (y === 0) return `${m}m`
+  if (m === 0) return `${y}y`
+  return `${y}y ${m}m`
 }
 
 function loadOverrides(): Map<string, SoundOverride> {
@@ -45,21 +72,26 @@ function saveOverrides(overrides: Map<string, SoundOverride>) {
 }
 
 function AppRoute() {
-  const [childAgeMonths, setChildAgeMonths] = useState<number | null>(null)
+  const [birthDate, setBirthDate] = useState<BirthDate | null>(null)
+  const [birthLoaded, setBirthLoaded] = useState(false)
   const [soundOverrides, setSoundOverrides] = useState<Map<string, SoundOverride>>(new Map())
   const [currentIndex, setCurrentIndex] = useState(0)
   const [filterOpen, setFilterOpen] = useState(false)
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS)
+  const [editingAge, setEditingAge] = useState(false)
 
   // Load persisted state on mount
   useEffect(() => {
-    setChildAgeMonths(loadAge())
+    setBirthDate(loadBirth())
+    setBirthLoaded(true)
     setSoundOverrides(loadOverrides())
   }, [])
 
+  const childAgeMonths = birthDate ? computeAgeMonths(birthDate) : 24
+
   // Compute cards
   const { cards, stats } = useCards({
-    childAgeMonths: childAgeMonths ?? 24,
+    childAgeMonths,
     soundOverrides,
     filters,
   })
@@ -96,9 +128,10 @@ function AppRoute() {
   }, [speak])
 
   // Handle age submission
-  const handleAgeSubmit = useCallback((age: number) => {
-    setChildAgeMonths(age)
-    saveAge(age)
+  const handleAgeSubmit = useCallback((ageMonths: number, birthMonth: number, birthYear: number) => {
+    saveBirth(birthMonth, birthYear)
+    setBirthDate({ month: birthMonth, year: birthYear })
+    setEditingAge(false)
     setCurrentIndex(0)
   }, [])
 
@@ -131,9 +164,18 @@ function AppRoute() {
   const currentCard = cards[currentIndex]
   usePrefetchAudio(currentCard)
 
-  // Age not set → show age entry
-  if (childAgeMonths === null) {
-    return <AgeEntry onSubmit={handleAgeSubmit} />
+  // Wait for localStorage to load before rendering
+  if (!birthLoaded) return null
+
+  // No birth date set, or editing → show age entry
+  if (!birthDate || editingAge) {
+    return (
+      <AgeEntry
+        onSubmit={handleAgeSubmit}
+        initialBirthMonth={birthDate?.month}
+        initialBirthYear={birthDate?.year}
+      />
+    )
   }
 
   return (
@@ -180,14 +222,14 @@ function AppRoute() {
         </span>
 
         <button
-          onClick={() => setChildAgeMonths(null)}
+          onClick={() => setEditingAge(true)}
           style={{
             fontSize: '14px',
             fontWeight: 600,
             color: 'var(--color-text-muted)',
           }}
         >
-          ⚙ {childAgeMonths}mo
+          ⚙ {formatAgeShort(childAgeMonths)}
         </button>
       </header>
 


### PR DESCRIPTION
## Summary
- Replace age slider with birth month/year dropdowns so the child's age stays accurate over time
- Persist birth date in localStorage and compute age dynamically on each visit
- Default filters now exclude Tier 3 (future sounds) — only show words the child is ready to practice
- Rename "Tier" filter section to "Practice mode" with descriptions for each tier (Produce, Guided, Listen)

## Test plan
- [x] Fresh visit to `/app` shows month/year dropdowns (no slider)
- [x] Select birth date, click Start — cards appear with correct age in header
- [x] Refresh — goes straight to cards (birth date persisted)
- [x] Click settings gear — AgeEntry pre-populated with stored birth date
- [x] Select out-of-range birth date (< 1 year or > 5 years) — Start button disabled
- [x] Open filters — all categories checked, Tier 3 (Listen) unchecked by default
- [x] Each tier shows a description of the practice approach