### PR TITLE
Prevent UI resize on iPhone when tapping buttons

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,7 +14,7 @@ export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover' },
       { title: 'Phoneme Word Trainer — Help Your Toddler Hear and Say New Sounds' },
       { name: 'description', content: 'A parent-led flashcard app for toddler speech development, based on speech sound acquisition research.' },
     ],

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -197,7 +197,7 @@ function AppRoute() {
   }
 
   return (
-    <div style={{ minHeight: '100dvh', background: 'var(--color-bg)', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ height: '100svh', overflow: 'hidden', background: 'var(--color-bg)', display: 'flex', flexDirection: 'column' }}>
       {/* Top bar — minimal, stays out of the way */}
       <header style={{
         display: 'flex',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,6 +10,7 @@
 html {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+  overscroll-behavior: none;
 }
 
 body {
@@ -46,6 +47,11 @@ button {
   border: none;
   cursor: pointer;
   padding: 0;
+  touch-action: manipulation;
+}
+
+a, [role="button"] {
+  touch-action: manipulation;
 }
 
 button:focus-visible,


### PR DESCRIPTION
## Summary

- **Viewport meta**: Added `maximum-scale=1` and `viewport-fit=cover` to prevent iOS auto-zoom on tap
- **Touch action**: Added `touch-action: manipulation` globally on buttons, links, and `[role="button"]` to disable double-tap zoom
- **Stable viewport height**: Switched app container from `minHeight: 100dvh` (dynamic — shifts when Safari address bar hides/shows) to `height: 100svh` (stable) with `overflow: hidden`
- **Overscroll**: Added `overscroll-behavior: none` on `html` to prevent iOS bounce/pull effects that cause layout shift

## Test plan

- [ ] On iPhone Safari, tap the Listen button — UI should not resize or zoom
- [ ] Tap phoneme letter segments — no resize
- [ ] Tap prev/next nav buttons — no resize
- [ ] Double-tap on buttons — should not zoom in
- [ ] Pull down on the page — should not rubber-band/bounce
- [ ] Verify the card still fills the screen correctly in both portrait and landscape
- [ ] Verify the AgeEntry screen still scrolls properly

https://claude.ai/code/session_01GhSchdTXmUBofXCPE8cLan