### PR TITLE
Landing: fact-check + align tier labels with app

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "bun",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/src/components/landing/Methodology.tsx
+++ b/src/components/landing/Methodology.tsx
@@ -40,7 +40,7 @@ export function Methodology() {
           <div className={`${styles.tierCard} ${styles.tierCardProduce}`}>
             <div>
               <span className={`${styles.tierDot} ${styles.tierDotProduce}`} />
-              <span className={styles.tierLabel}>Produce</span>
+              <span className={styles.tierLabel}>In reach</span>
             </div>
             <p className={styles.tierDesc}>
               Your child can make this sound. Isolate the first phoneme, then
@@ -50,7 +50,7 @@ export function Methodology() {
           <div className={`${styles.tierCard} ${styles.tierCardGuided}`}>
             <div>
               <span className={`${styles.tierDot} ${styles.tierDotGuided}`} />
-              <span className={styles.tierLabel}>Guided</span>
+              <span className={styles.tierLabel}>Stretch</span>
             </div>
             <p className={styles.tierDesc}>
               This sound is emerging. Model with emphasis: "Kuh... Cat!" Accept
@@ -60,10 +60,10 @@ export function Methodology() {
           <div className={`${styles.tierCard} ${styles.tierCardExpose}`}>
             <div>
               <span className={`${styles.tierDot} ${styles.tierDotExpose}`} />
-              <span className={styles.tierLabel}>Listen</span>
+              <span className={styles.tierLabel}>Out of reach</span>
             </div>
             <p className={styles.tierDesc}>
-              Not expected yet. Stretch the sound: "Bllllue." Your child will
+              Not expected yet. Draw out the sound: "Bllllue." Your child will
               simplify, and that's perfectly normal.
             </p>
           </div>
@@ -81,13 +81,13 @@ export function Methodology() {
               consonant development.
             </li>
             <li className={styles.scienceItem}>
-              212 words tagged by constituent consonant sounds, acquisition
+              635 words tagged by constituent consonant sounds, acquisition
               difficulty, and common simplification patterns.
             </li>
             <li className={styles.scienceItem}>
               Uses recasting — modeling the correct form without correcting —
-              which research shows is the most effective parent technique for
-              speech development.
+              one of the most well-supported parent techniques in the speech
+              development literature.
             </li>
             <li className={styles.scienceItem}>
               Phonological processes like fronting ("cat" → "tat") and cluster


### PR DESCRIPTION
## Summary
- **Fact fix**: word count on the Methodology page said 212; actual is 635 (verified via `bun -e` on `src/data/words.ts`).
- **Softer science claim**: removed the unsupported "most effective parent technique" line about recasting — replaced with "one of the most well-supported parent techniques in the speech development literature." No systematic review crowns recasting #1 for speech (as opposed to grammar/language).
- **Nomenclature alignment**: landing tier labels (Produce / Guided / Listen) didn't match the app's FilterPanel, WordOverview, and WordSearch (In reach / Stretch / Out of reach). Landing now uses the app's labels. Also reworded the Tier 3 description ("Stretch the sound" → "Draw out the sound") so the verb no longer collides with the new "Stretch" tier label.
- **DX**: `.claude/launch.json` gains `autoPort: true` so `preview_start` doesn't fail when another worktree is holding port 3000.

## Verified accurate (no change)
- Crowe & McLeod 2020 citation (AJSLP 29(4))
- Phonological process examples (cat→tat fronting, blue→boo cluster reduction)
- Tier descriptions still match engine behavior in `tierComputation.ts` / `drillMode.ts`

## Test plan
- [x] `bun run build` passes
- [x] SSR fetch of `/` shows all four edits (635, In reach / Stretch / Out of reach, well-supported, Draw out)
- [ ] Eyeball landing page in browser — tier cards and science bullets read correctly