### PR TITLE
Fix iPad landscape: card clipped/scrollable on short viewports

### DIFF
--- a/src/components/app/Card.module.css
+++ b/src/components/app/Card.module.css
@@ -253,3 +253,45 @@
     max-width: 700px;
   }
 }
+
+/* Short landscape (tablets rotated, laptops with low-res screens) — keep the card in view without page scroll */
+@media (min-width: 768px) and (max-height: 900px) and (orientation: landscape) {
+  .imageArea {
+    height: 200px;
+    font-size: 90px;
+  }
+
+  .imageLabel {
+    font-size: 22px;
+    margin-top: var(--space-xs);
+  }
+
+  .content {
+    padding: var(--space-md) var(--space-lg) var(--space-sm);
+    gap: var(--space-md);
+  }
+
+  .wordRow {
+    font-size: clamp(40px, 6vw, 64px);
+  }
+
+  .hearItButton {
+    height: 52px;
+    font-size: 18px;
+    max-width: 300px;
+  }
+
+  .tipText {
+    font-size: 14px;
+    min-height: calc(2 * 1.5 * 14px);
+  }
+
+  .actionBar {
+    padding-top: var(--space-xs);
+  }
+
+  .navButton {
+    width: 44px;
+    height: 44px;
+  }
+}


### PR DESCRIPTION
## Summary
- On iPad landscape (1024×768, 1133×744 iPad mini, 1180×820 iPad Air, etc.) the flashcard at the `min-width: 1024px` breakpoint totals ~760px tall, which exceeds the viewport once the 52px header is subtracted. The outer `100svh` container uses `overflow: hidden`, so the card ends up clipped and the listen button / nav bar can fall off-screen.
- Adds a short-landscape media query (`min-width: 768px`, `max-height: 900px`, `orientation: landscape`) that shrinks the image area, content padding/gap, word row, listen button, and nav buttons so the whole card fits comfortably without page scroll.
- Desktop/large-viewport look is unchanged — the query only activates on short landscape.

## Test plan
- [ ] Open the preview deployment on an iPad in landscape (or Chrome devtools at 1024×768, 1133×744, 1180×820, 1366×1024) and confirm the full card — image, word, listen button, tip, and nav arrows — is visible without vertical scrolling.
- [ ] Verify portrait iPad (820×1180, 768×1024) still looks the same.
- [ ] Verify desktop (≥ 1024×901+) is unchanged.
- [ ] Verify phone portrait (<768px) is unchanged.

Note: I couldn't verify locally — `vite dev` in this worktree 404s on `/@id/virtual:tanstack-start-client-entry` for the `/app` route, so the page never hydrates in the local preview. Relying on the Cloudflare preview deployment for visual verification.