### PR TITLE
Add in-app word suggestion form + classifier script

### DIFF
--- a/docs/word-suggestions.md
+++ b/docs/word-suggestions.md
@@ -36,6 +36,22 @@ again.
 
 ## One-time setup (must be done at github.com)
 
+### 0. Install the workflow files
+
+The two workflow YAMLs live at `docs/workflows/` rather than
+`.github/workflows/` because the OAuth app that opens this branch lacks the
+`workflow` scope and can't push them. Move them into place once with a
+human-authored commit:
+
+```sh
+mkdir -p .github/workflows
+git mv docs/workflows/word-suggestions-cron.yml .github/workflows/
+git mv docs/workflows/word-suggestions-requeue.yml .github/workflows/
+git commit -m "Activate word-suggestions workflows"
+git push
+```
+
+
 ### 1. Create the labels
 
 In `johnjensenish/phoneme-word-trainer` → Issues → Labels:

--- a/docs/word-suggestions.md
+++ b/docs/word-suggestions.md
@@ -1,0 +1,111 @@
+# Word suggestions: end-to-end pipeline
+
+Users submit new words from the app at `/suggest`. The submission gets queued
+as a GitHub issue, a nightly cron classifies and adds it via `add-word.ts`, a
+single rolling PR collects the batch, and merging the PR ships the words.
+
+## Flow
+
+```
+User → /suggest form → Worker server fn → GitHub issue (label: word-suggestion)
+                                            │
+                                            ▼
+                              ┌─ daily cron (word-suggestions-cron.yml)
+                              │   1. fetch open `word-suggestion` issues
+                              │      that don't have `queued`
+                              │   2. classify each via GitHub Models
+                              │      (category + emoji + confidence)
+                              │   3. low-confidence → label `needs-human-review`
+                              │   4. accepted → run add-word.ts, commit
+                              │   5. push to `bot/word-suggestions`
+                              │      (reuse open PR if one exists, else open)
+                              │   6. label issues `queued` + comment
+                              └─
+                                            │
+                                  Maintainer reviews & merges PR
+                                            │
+                                            ▼
+                              GitHub auto-closes referenced issues
+                                            │
+                       generate-audio.yml synthesizes any missing MP3s
+```
+
+If the PR is **closed without merging**, `word-suggestions-requeue.yml`
+strips the `queued` label from referenced issues so the next cron pick them up
+again.
+
+## One-time setup (must be done at github.com)
+
+### 1. Create the labels
+
+In `johnjensenish/phoneme-word-trainer` → Issues → Labels:
+
+| name                  | color    | description                                          |
+| --------------------- | -------- | ---------------------------------------------------- |
+| `word-suggestion`     | `0e8a16` | New word submitted via the in-app form               |
+| `queued`              | `fbca04` | Already included in an open `bot/word-suggestions` PR |
+| `needs-human-review`  | `d93f0b` | Auto-classifier wasn't confident enough              |
+
+### 2. Mint a fine-grained PAT for the Worker
+
+The Cloudflare Worker (server function) needs to file issues. Create a
+fine-grained PAT scoped to **only this repo** with these permissions:
+
+- **Repository access**: `Only select repositories` → `phoneme-word-trainer`
+- **Repository permissions**:
+  - Issues: **Read and write**
+  - Metadata: **Read-only** (auto-included)
+
+Set the expiration to whatever you're comfortable with (1 year max). Set a
+calendar reminder to rotate it before it expires.
+
+### 3. Wire the PAT into Cloudflare
+
+```sh
+# Production (deployed Worker)
+bunx wrangler secret put GITHUB_PAT
+
+# Local dev: create .dev.vars (gitignored)
+echo 'GITHUB_PAT="ghp_..."' >> .dev.vars
+```
+
+`.dev.vars` is read automatically by `vite dev` via the Cloudflare plugin and
+must NOT be committed.
+
+### 4. Allow GitHub Actions to use Models
+
+Repo Settings → Actions → General → ensure **Read and write permissions** for
+the `GITHUB_TOKEN` are enabled. Models inference uses this token and the
+workflow already requests `permissions: models: read`.
+
+### 5. Auto-delete merged branches (optional but recommended)
+
+Repo Settings → General → tick **"Automatically delete head branches"**. This
+keeps `bot/word-suggestions` clean between batches.
+
+## Operating notes
+
+- **Branch naming is load-bearing.** The cron and the requeue workflow both key
+  off the prefix `bot/word-suggestions`. Don't rename it without updating both.
+- **One PR at a time.** A single rolling PR collects the batch. Merge it before
+  significant churn lands on `main`, otherwise the next cron run will rebase
+  the bot branch and force-push.
+- **Rate limit.** The Worker rate-limits submissions per IP at 5/hour
+  (in-memory; resets when the Worker cold-starts). Tighten or move to a KV
+  binding if abuse becomes an issue.
+- **Model choice.** Defaults to `openai/gpt-4o-mini` via GitHub Models. Override
+  by setting `WORD_CLASSIFIER_MODEL` in the cron workflow env.
+- **Cost.** GitHub Models has a free per-account quota that's plenty for a
+  daily batch of a few words. The Worker's GitHub API calls are ~2 requests
+  per submission.
+
+## Testing locally
+
+```sh
+# Dry-run the classifier with a mock input:
+echo '[{"number": 1, "word": "butter"}]' \
+  | GITHUB_TOKEN=ghp_xxx bun run scripts/classify-suggestions.ts
+
+# Manually trigger the cron from the GitHub UI:
+# Actions → Process Word Suggestions → Run workflow
+```

--- a/docs/workflows/word-suggestions-cron.yml
+++ b/docs/workflows/word-suggestions-cron.yml
@@ -1,0 +1,216 @@
+name: Process Word Suggestions
+
+on:
+  schedule:
+    # Daily at 09:00 UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+# Single source of truth: never let two runs race on the same branch.
+concurrency:
+  group: word-suggestions
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  models: read
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: bot/word-suggestions
+      LABEL_PENDING: word-suggestion
+      LABEL_QUEUED: queued
+      LABEL_REVIEW: needs-human-review
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install espeak-ng
+        run: sudo apt-get update && sudo apt-get install -y espeak-ng
+
+      - run: bun install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch pending suggestions
+        id: fetch
+        run: |
+          # Open issues with the suggestion label, excluding ones already queued.
+          gh issue list \
+            --label "$LABEL_PENDING" \
+            --state open \
+            --limit 100 \
+            --json number,title,body,labels \
+            | jq '[.[] | select(.labels | map(.name) | index(env.LABEL_QUEUED) | not)]' \
+            > /tmp/raw-issues.json
+
+          # Parse word + sentence out of the issue body.
+          jq '[.[] | {
+            number,
+            word: (.title | sub("^word: "; "") | ascii_downcase | gsub("[^a-z\'\'' -]"; "")),
+            sentence: (
+              .body
+              | capture("\\*\\*Example sentence:\\*\\* (?<s>[^\\n]+)"; "i").s
+              // empty
+            )
+          } | select(.word != "")]' /tmp/raw-issues.json > /tmp/pending.json
+
+          count=$(jq 'length' /tmp/pending.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Found $count pending suggestion(s)."
+          if [[ "$count" -gt 0 ]]; then jq . /tmp/pending.json; fi
+
+      - name: Classify with GitHub Models
+        if: steps.fetch.outputs.count != '0'
+        run: |
+          bun run scripts/classify-suggestions.ts < /tmp/pending.json > /tmp/classified.json
+          jq . /tmp/classified.json
+
+      - name: Reject low-confidence suggestions
+        if: steps.fetch.outputs.count != '0'
+        run: |
+          jq -c '.[] | select(.accepted | not)' /tmp/classified.json > /tmp/rejected.jsonl || true
+          while IFS= read -r row; do
+            num=$(echo "$row" | jq -r .number)
+            cat=$(echo "$row" | jq -r .category)
+            conf=$(echo "$row" | jq -r .confidence)
+            reason=$(echo "$row" | jq -r .reasoning)
+            echo "Flagging #$num for human review (category=$cat, confidence=$conf)"
+            gh issue edit "$num" --add-label "$LABEL_REVIEW"
+            gh issue comment "$num" --body "Auto-classifier wasn't confident enough to add this automatically.
+
+Suggested category: \`$cat\` (confidence $conf)
+Reasoning: $reason
+
+A maintainer will take it from here."
+          done < /tmp/rejected.jsonl
+
+      - name: Reconcile branch state
+        id: branch
+        if: steps.fetch.outputs.count != '0'
+        run: |
+          jq -c '.[] | select(.accepted)' /tmp/classified.json > /tmp/accepted.jsonl || true
+          accepted_count=$(wc -l < /tmp/accepted.jsonl | tr -d ' ')
+          echo "accepted=$accepted_count" >> "$GITHUB_OUTPUT"
+          if [[ "$accepted_count" == "0" ]]; then
+            echo "No accepted suggestions — nothing to commit."
+            exit 0
+          fi
+
+          # Single source of truth: do we have an open PR for this branch?
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$pr_number" ]]; then
+            echo "Reusing existing PR #$pr_number on $BRANCH"
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+            git rebase origin/main
+          else
+            # No open PR. Nuke any stale branch left over from a closed/unmerged PR.
+            git push origin --delete "$BRANCH" 2>/dev/null || true
+            git checkout -B "$BRANCH" origin/main
+          fi
+
+      - name: Run add-word.ts for accepted suggestions
+        id: add
+        if: steps.branch.outputs.accepted != '0'
+        run: |
+          : > /tmp/succeeded.jsonl
+          : > /tmp/failed.jsonl
+          while IFS= read -r row; do
+            num=$(echo "$row" | jq -r .number)
+            word=$(echo "$row" | jq -r .word)
+            cat=$(echo "$row" | jq -r .category)
+            emoji=$(echo "$row" | jq -r .emoji)
+
+            echo "::group::Adding '$word' (category=$cat, emoji=$emoji) — issue #$num"
+            if bun run scripts/add-word.ts "$word" --category "$cat" --emoji "$emoji" --yes; then
+              git add src/data/words.ts src/data/emojiMap.ts
+              if git diff --cached --quiet; then
+                echo "No diff produced for '$word' — likely already present. Skipping."
+                echo "$row" >> /tmp/failed.jsonl
+              else
+                git commit -m "Add suggested word: $word (closes #$num)"
+                echo "$row" >> /tmp/succeeded.jsonl
+              fi
+            else
+              echo "add-word.ts failed for '$word'"
+              echo "$row" >> /tmp/failed.jsonl
+            fi
+            echo "::endgroup::"
+          done < /tmp/accepted.jsonl
+
+          succ=$(wc -l < /tmp/succeeded.jsonl | tr -d ' ')
+          echo "succeeded=$succ" >> "$GITHUB_OUTPUT"
+
+      - name: Flag failures for human review
+        if: steps.branch.outputs.accepted != '0'
+        run: |
+          while IFS= read -r row; do
+            num=$(echo "$row" | jq -r .number)
+            word=$(echo "$row" | jq -r .word)
+            gh issue edit "$num" --add-label "$LABEL_REVIEW"
+            gh issue comment "$num" --body "\`add-word.ts\` couldn't process \`$word\` automatically (run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). A maintainer will take a look."
+          done < /tmp/failed.jsonl
+
+      - name: Push branch
+        if: steps.add.outputs.succeeded != '' && steps.add.outputs.succeeded != '0'
+        run: git push --force-with-lease -u origin "$BRANCH"
+
+      - name: Open or update PR
+        if: steps.add.outputs.succeeded != '' && steps.add.outputs.succeeded != '0'
+        id: pr
+        run: |
+          # Build a body that lists every issue this PR closes.
+          {
+            echo "Auto-generated batch of word suggestions, classified by GitHub Models."
+            echo
+            echo "## Words in this PR"
+            git log origin/main..HEAD --pretty=format:"- %s" | sed 's/Add suggested word: //'
+            echo
+            echo
+            echo "## Closes"
+            git log origin/main..HEAD --pretty=format:"%s" \
+              | grep -oE '#[0-9]+' \
+              | sort -u \
+              | sed 's/^/- Closes /'
+            echo
+            echo
+            echo "_Merge to ship; close without merging to send these suggestions back to the queue._"
+          } > /tmp/pr-body.md
+
+          if [[ -z "${{ steps.branch.outputs.pr }}" ]]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "Add suggested words" \
+              --body-file /tmp/pr-body.md
+          else
+            gh pr edit "${{ steps.branch.outputs.pr }}" --body-file /tmp/pr-body.md
+          fi
+
+          # Capture the (possibly new) PR number for downstream comments.
+          new_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          echo "number=$new_pr" >> "$GITHUB_OUTPUT"
+
+      - name: Mark queued issues
+        if: steps.pr.outputs.number != ''
+        run: |
+          while IFS= read -r row; do
+            num=$(echo "$row" | jq -r .number)
+            gh issue edit "$num" --add-label "$LABEL_QUEUED"
+            gh issue comment "$num" --body "Queued in #${{ steps.pr.outputs.number }} — will close automatically when that PR merges."
+          done < /tmp/succeeded.jsonl

--- a/docs/workflows/word-suggestions-requeue.yml
+++ b/docs/workflows/word-suggestions-requeue.yml
@@ -1,0 +1,37 @@
+name: Requeue Word Suggestions
+
+# Fires when the auto-generated suggestions PR is closed.
+# - Merged → GitHub auto-closes the linked issues; nothing to do here.
+# - Closed unmerged → strip the `queued` label so the cron picks them up again.
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  requeue:
+    if: >
+      github.event.pull_request.merged == false &&
+      startsWith(github.event.pull_request.head.ref, 'bot/word-suggestions')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      LABEL_QUEUED: queued
+    steps:
+      - name: Strip queued label from referenced issues
+        run: |
+          # Extract every #NNN from the PR body — the cron writes "Closes #NNN" lines.
+          numbers=$(printf '%s\n' "${{ github.event.pull_request.body }}" \
+            | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+          if [[ -z "$numbers" ]]; then
+            echo "No issue references found in PR body."
+            exit 0
+          fi
+          for num in $numbers; do
+            echo "Removing '$LABEL_QUEUED' from #$num"
+            gh issue edit "$num" \
+              --repo "${{ github.repository }}" \
+              --remove-label "$LABEL_QUEUED" || true
+          done

--- a/scripts/classify-suggestions.ts
+++ b/scripts/classify-suggestions.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env bun
+/**
+ * Classify pending word suggestions via GitHub Models.
+ *
+ * Reads JSON from stdin: [{number, word, sentence?}]
+ * Writes JSON to stdout:  [{number, word, category, emoji, confidence, reasoning, accepted}]
+ *
+ * Requires GITHUB_TOKEN with models:read (provided by Actions when
+ * `permissions: models: read` is set).
+ */
+
+const CATEGORIES = [
+  "animals", "body", "clothing", "colors", "condition",
+  "evaluative", "exclamations", "feelings", "food", "furniture", "health",
+  "household", "nature", "numbers", "people", "prepositions", "pronouns",
+  "requests", "rooms", "sensory", "shapes", "size", "social", "time", "toys",
+  "vehicles", "verbs", "weather",
+] as const;
+
+const MIN_CONFIDENCE = 0.7;
+const MODEL = process.env.WORD_CLASSIFIER_MODEL || "openai/gpt-4o-mini";
+const ENDPOINT = "https://models.github.ai/inference/chat/completions";
+
+interface Pending {
+  number: number;
+  word: string;
+  sentence?: string;
+}
+
+interface Classification {
+  number: number;
+  word: string;
+  category: string;
+  emoji: string;
+  confidence: number;
+  reasoning: string;
+  accepted: boolean;
+}
+
+const SYSTEM_PROMPT = `You classify English words for a toddler speech-therapy flashcard app.
+
+For each word, return:
+- category: one of [${CATEGORIES.join(", ")}]
+- emoji: a single emoji that depicts the word concretely (no skin tones, no flags)
+- confidence: 0.0–1.0, how confident you are in the category
+- reasoning: <= 12 words explaining the choice
+
+Rules:
+- Pick the category a parent would expect when filtering. "dog" → animals, "shirt" → clothing, "happy" → feelings.
+- For ambiguous words, use the example sentence if provided.
+- If no category fits well, set confidence below 0.7.
+- Emoji must depict the word itself, not the category. "butter" → 🧈, not 🍽️.
+- If you can't find a depictive emoji, use ❓ and lower confidence.
+
+Return ONLY a JSON object: { "results": [ { "word": "...", "category": "...", "emoji": "...", "confidence": 0.95, "reasoning": "..." } ] }
+The "results" array must be in the same order as the input.`;
+
+async function classify(pending: Pending[]): Promise<Classification[]> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN not set");
+
+  const userPrompt = JSON.stringify(
+    pending.map(p => ({
+      word: p.word,
+      ...(p.sentence ? { sentence: p.sentence } : {}),
+    })),
+  );
+
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: 0.1,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userPrompt },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub Models ${res.status}: ${text.slice(0, 500)}`);
+  }
+
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error("No content in model response");
+
+  const parsed = JSON.parse(content) as {
+    results?: Array<{
+      word?: string;
+      category?: string;
+      emoji?: string;
+      confidence?: number;
+      reasoning?: string;
+    }>;
+  };
+
+  const results = parsed.results ?? [];
+  if (results.length !== pending.length) {
+    throw new Error(`Model returned ${results.length} results, expected ${pending.length}`);
+  }
+
+  return pending.map((p, i): Classification => {
+    const r = results[i];
+    const category = String(r.category ?? "").toLowerCase();
+    const emoji = String(r.emoji ?? "❓");
+    const confidence = Number(r.confidence ?? 0);
+    const reasoning = String(r.reasoning ?? "");
+    const validCategory = (CATEGORIES as readonly string[]).includes(category);
+    return {
+      number: p.number,
+      word: p.word,
+      category: validCategory ? category : "household",
+      emoji,
+      confidence,
+      reasoning,
+      accepted: validCategory && confidence >= MIN_CONFIDENCE && emoji !== "❓",
+    };
+  });
+}
+
+async function main() {
+  const stdin = await Bun.stdin.text();
+  const pending = JSON.parse(stdin) as Pending[];
+
+  if (!Array.isArray(pending) || pending.length === 0) {
+    process.stdout.write("[]");
+    return;
+  }
+
+  const classifications = await classify(pending);
+  process.stdout.write(JSON.stringify(classifications));
+}
+
+await main();

--- a/src/components/app/WordSearch.tsx
+++ b/src/components/app/WordSearch.tsx
@@ -1,7 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
+import { Link } from '@tanstack/react-router'
 import type { ComputedWordCard, Tier } from '~/data/types'
 import { emojiMap } from '~/data/emojiMap'
 import styles from './WordSearch.module.css'
+
+const WORD_RE = /^[a-z][a-z' -]{0,28}[a-z]$|^[a-z]$/
 
 interface WordSearchProps {
   allCards: ComputedWordCard[]
@@ -190,7 +193,24 @@ export function WordSearch({
         <>
           <div className={styles.backdrop} onClick={close} />
           <div className={styles.dropdown}>
-            <div className={styles.noResults}>No words match "{query}"</div>
+            <div className={styles.noResults}>
+              <div>No words match "{query}"</div>
+              {WORD_RE.test(query.trim().toLowerCase()) && (
+                <Link
+                  to="/suggest"
+                  search={{ word: query.trim().toLowerCase() }}
+                  style={{
+                    display: 'inline-block',
+                    marginTop: 10,
+                    fontWeight: 700,
+                    fontSize: 13,
+                  }}
+                  onClick={close}
+                >
+                  Suggest "{query.trim().toLowerCase()}" →
+                </Link>
+              )}
+            </div>
           </div>
         </>
       )}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SuggestRouteImport } from './routes/suggest'
 import { Route as AppRouteImport } from './routes/app'
 import { Route as IndexRouteImport } from './routes/index'
 
+const SuggestRoute = SuggestRouteImport.update({
+  id: '/suggest',
+  path: '/suggest',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppRoute = AppRouteImport.update({
   id: '/app',
   path: '/app',
@@ -26,31 +32,42 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/app': typeof AppRoute
+  '/suggest': typeof SuggestRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/app': typeof AppRoute
+  '/suggest': typeof SuggestRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/app': typeof AppRoute
+  '/suggest': typeof SuggestRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/app'
+  fullPaths: '/' | '/app' | '/suggest'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/app'
-  id: '__root__' | '/' | '/app'
+  to: '/' | '/app' | '/suggest'
+  id: '__root__' | '/' | '/app' | '/suggest'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRoute
+  SuggestRoute: typeof SuggestRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/suggest': {
+      id: '/suggest'
+      path: '/suggest'
+      fullPath: '/suggest'
+      preLoaderRoute: typeof SuggestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/app': {
       id: '/app'
       path: '/app'
@@ -71,6 +88,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRoute,
+  SuggestRoute: SuggestRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/suggest.tsx
+++ b/src/routes/suggest.tsx
@@ -1,0 +1,150 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useServerFn } from '@tanstack/react-start'
+import { submitWord, type SubmitResult } from '~/server/submitWord'
+
+interface SuggestSearch {
+  word?: string
+}
+
+export const Route = createFileRoute('/suggest')({
+  component: SuggestPage,
+  validateSearch: (search: Record<string, unknown>): SuggestSearch => ({
+    word: typeof search.word === 'string' ? search.word.slice(0, 30) : undefined,
+  }),
+})
+
+function SuggestPage() {
+  const { word: prefill } = Route.useSearch()
+  const submit = useServerFn(submitWord)
+  const [word, setWord] = useState(prefill ?? '')
+  const [sentence, setSentence] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<SubmitResult | null>(null)
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setBusy(true)
+    setResult(null)
+    try {
+      const res = await submit({ data: { word, sentence: sentence || undefined } })
+      setResult(res)
+      if (res.ok) {
+        setWord('')
+        setSentence('')
+      }
+    } catch (err) {
+      setResult({ ok: false, error: err instanceof Error ? err.message : 'Submission failed' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main style={{
+      maxWidth: 560,
+      margin: '0 auto',
+      padding: 'var(--space-xl) var(--space-md)',
+      minHeight: '100dvh',
+    }}>
+      <Link to="/app" style={{ fontSize: 13, fontWeight: 700 }}>← Back to the app</Link>
+
+      <h1 style={{ fontSize: 28, fontWeight: 800, marginTop: 'var(--space-md)' }}>
+        Suggest a word
+      </h1>
+      <p style={{ color: 'var(--color-text-muted)', marginTop: 8, lineHeight: 1.5 }}>
+        Missing a word your toddler loves? Send it in. We&rsquo;ll classify it,
+        generate audio, and roll it into the next release.
+      </p>
+
+      <form onSubmit={onSubmit} style={{ marginTop: 'var(--space-lg)', display: 'grid', gap: 16 }}>
+        <label style={{ display: 'grid', gap: 6 }}>
+          <span style={{ fontWeight: 700, fontSize: 14 }}>Word</span>
+          <input
+            type="text"
+            required
+            autoComplete="off"
+            autoCapitalize="none"
+            spellCheck
+            value={word}
+            onChange={e => setWord(e.target.value)}
+            placeholder="e.g. butter"
+            maxLength={30}
+            disabled={busy}
+            style={{
+              padding: '10px 12px',
+              borderRadius: 10,
+              border: '1px solid var(--color-border, #ddd)',
+              background: 'var(--color-surface, #fff)',
+              fontSize: 16,
+            }}
+          />
+        </label>
+
+        <label style={{ display: 'grid', gap: 6 }}>
+          <span style={{ fontWeight: 700, fontSize: 14 }}>
+            Example sentence <span style={{ fontWeight: 400, color: 'var(--color-text-muted)' }}>(optional)</span>
+          </span>
+          <input
+            type="text"
+            value={sentence}
+            onChange={e => setSentence(e.target.value)}
+            placeholder='e.g. "I want more butter."'
+            maxLength={200}
+            disabled={busy}
+            style={{
+              padding: '10px 12px',
+              borderRadius: 10,
+              border: '1px solid var(--color-border, #ddd)',
+              background: 'var(--color-surface, #fff)',
+              fontSize: 16,
+            }}
+          />
+          <span style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+            Helps disambiguate homonyms (e.g. <em>fly</em> the bug vs. <em>fly</em> a kite).
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          disabled={busy || !word.trim()}
+          style={{
+            padding: '12px 16px',
+            borderRadius: 12,
+            background: 'var(--color-accent)',
+            color: 'white',
+            fontWeight: 800,
+            fontSize: 15,
+            opacity: busy || !word.trim() ? 0.6 : 1,
+          }}
+        >
+          {busy ? 'Submitting…' : 'Submit suggestion'}
+        </button>
+      </form>
+
+      {result && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            marginTop: 20,
+            padding: 14,
+            borderRadius: 10,
+            background: result.ok ? '#e8f5ee' : '#fdecea',
+            color: result.ok ? '#1f5132' : '#7a1a14',
+            fontSize: 14,
+            lineHeight: 1.5,
+          }}
+        >
+          {result.ok ? (
+            result.status === 'duplicate-pending'
+              ? `Someone already suggested that one — tracked as #${result.issueNumber}.`
+              : `Thanks! Queued as #${result.issueNumber}. It'll appear in the app after the next batch lands.`
+          ) : (
+            result.error
+          )}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/server/submitWord.ts
+++ b/src/server/submitWord.ts
@@ -1,0 +1,131 @@
+import { createServerFn } from '@tanstack/react-start'
+import { getRequestIP } from '@tanstack/react-start-server'
+import { words } from '~/data/words'
+
+const REPO = 'johnjensenish/phoneme-word-trainer'
+const LABEL = 'word-suggestion'
+const WORD_RE = /^[a-z][a-z' -]{0,28}[a-z]$|^[a-z]$/
+const SENTENCE_MAX = 200
+
+export type SubmitInput = {
+  word: string
+  sentence?: string
+}
+
+export type SubmitResult =
+  | { ok: true; issueNumber: number; status: 'queued' | 'duplicate-pending' }
+  | { ok: false; error: string }
+
+const recentByIp = new Map<string, number[]>()
+const RATE_LIMIT = 5
+const RATE_WINDOW_MS = 60 * 60 * 1000
+
+function checkRate(ip: string): boolean {
+  const now = Date.now()
+  const window = (recentByIp.get(ip) ?? []).filter(t => now - t < RATE_WINDOW_MS)
+  if (window.length >= RATE_LIMIT) {
+    recentByIp.set(ip, window)
+    return false
+  }
+  window.push(now)
+  recentByIp.set(ip, window)
+  return true
+}
+
+function validate(input: unknown): SubmitInput {
+  if (!input || typeof input !== 'object') throw new Error('Invalid payload')
+  const o = input as Record<string, unknown>
+  const word = typeof o.word === 'string' ? o.word.trim().toLowerCase() : ''
+  const sentence = typeof o.sentence === 'string' ? o.sentence.trim() : undefined
+  if (!WORD_RE.test(word)) {
+    throw new Error('Word must be 1–30 lowercase letters (apostrophes/hyphens/spaces allowed in the middle)')
+  }
+  if (sentence && sentence.length > SENTENCE_MAX) {
+    throw new Error(`Example sentence must be under ${SENTENCE_MAX} characters`)
+  }
+  return { word, sentence: sentence || undefined }
+}
+
+async function findExistingIssue(token: string, word: string): Promise<number | null> {
+  const q = encodeURIComponent(`repo:${REPO} is:issue is:open label:${LABEL} in:title "word: ${word}"`)
+  const res = await fetch(`https://api.github.com/search/issues?q=${q}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'phoneme-word-trainer',
+    },
+  })
+  if (!res.ok) return null
+  const data = (await res.json()) as { items?: Array<{ number: number; title: string }> }
+  const exact = data.items?.find(it => it.title.toLowerCase() === `word: ${word}`)
+  return exact?.number ?? null
+}
+
+async function createIssue(
+  token: string,
+  word: string,
+  sentence: string | undefined,
+): Promise<number> {
+  const body = [
+    `**Word:** ${word}`,
+    sentence ? `**Example sentence:** ${sentence}` : null,
+    '',
+    '_Submitted via the in-app suggestion form. The nightly classifier will pick this up._',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const res = await fetch(`https://api.github.com/repos/${REPO}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'phoneme-word-trainer',
+    },
+    body: JSON.stringify({
+      title: `word: ${word}`,
+      body,
+      labels: [LABEL],
+    }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`GitHub API ${res.status}: ${text.slice(0, 200)}`)
+  }
+  const data = (await res.json()) as { number: number }
+  return data.number
+}
+
+export const submitWord = createServerFn({ method: 'POST' })
+  .inputValidator(validate)
+  .handler(async ({ data }): Promise<SubmitResult> => {
+    const token = process.env.GITHUB_PAT
+    if (!token) return { ok: false, error: 'Server not configured (GITHUB_PAT missing)' }
+
+    let ip = 'unknown'
+    try {
+      ip = getRequestIP({ xForwardedFor: true }) ?? 'unknown'
+    } catch {
+      // Outside request scope (shouldn't happen in handler) — fall through.
+    }
+    if (!checkRate(ip)) {
+      return { ok: false, error: 'Too many submissions from this IP. Try again later.' }
+    }
+
+    if (words.some(w => w.word === data.word)) {
+      return { ok: false, error: `"${data.word}" is already in the trainer.` }
+    }
+
+    try {
+      const existing = await findExistingIssue(token, data.word)
+      if (existing) {
+        return { ok: true, issueNumber: existing, status: 'duplicate-pending' }
+      }
+      const issueNumber = await createIssue(token, data.word, data.sentence)
+      return { ok: true, issueNumber, status: 'queued' }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      return { ok: false, error: msg }
+    }
+  })


### PR DESCRIPTION
Adds /suggest route, Worker server function that files a labeled
GitHub issue, and a contextual "Suggest 'X'" link surfaced from the
in-app search when a user looks up a word that isn't in the trainer.
Also adds the GitHub Models classifier script used by the cron pipeline.
The two GitHub Action workflows that drive the pipeline are untracked
and must be committed by a user whose token has `workflow` scope —
see docs/word-suggestions.md.