### PR TITLE
Fire next/previous on press down

### DIFF
--- a/src/components/app/Card.tsx
+++ b/src/components/app/Card.tsx
@@ -89,12 +89,12 @@ export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldow
         )}
 
         <div className={styles.actionBar}>
-          <button className={`${styles.navButton} ${styles.navPrev}`} onClick={onPrev} aria-label="Previous word">
+          <button className={`${styles.navButton} ${styles.navPrev}`} onPointerDown={onPrev} aria-label="Previous word">
             <ArrowIcon direction="left" />
             <span>Previous</span>
           </button>
           <div className={styles.actionBarSpacer} />
-          <button className={`${styles.navButton} ${styles.navNext}`} onClick={onNext} aria-label="Next word">
+          <button className={`${styles.navButton} ${styles.navNext}`} onPointerDown={onNext} aria-label="Next word">
             <span>Next</span>
             <ArrowIcon direction="right" />
           </button>


### PR DESCRIPTION
## Summary
- Switch Previous/Next buttons from `onClick` to `onPointerDown` so they fire on press, matching the phoneme tiles and Listen button. Feels more responsive for toddlers.

Note: shake-to-undo isn't a feature in this app — it's iOS's system-level prompt and can't be disabled from a PWA. Use Guided Access with the Motion option turned off, or disable Shake to Undo system-wide in Accessibility settings.

## Test plan
- [ ] Tap Previous/Next on touch — card advances on finger-down, before release.
- [ ] Keyboard arrow keys still navigate.
- [ ] Toddler-mode cooldown still applies (button-mash protection unchanged).

https://claude.ai/code/session_01K6pKrY5TyoNKAt6ibQbMmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6pKrY5TyoNKAt6ibQbMmm)_