### PR TITLE
Add fullscreen card layouts with toggle

### DIFF
--- a/src/components/app/Card.module.css
+++ b/src/components/app/Card.module.css
@@ -375,8 +375,35 @@
     height: 30px;
   }
 
+  /* Side-pin nav buttons to viewport edges, like landscape. */
   .actionBar {
-    padding-top: var(--space-md);
+    height: 0;
+    padding: 0;
+    border-top: none;
+    overflow: visible;
+  }
+
+  .actionBarSpacer {
+    display: none;
+  }
+
+  .navButton {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: var(--z-action-bar);
+  }
+
+  .navPrev {
+    left: max(var(--space-lg), env(safe-area-inset-left));
+  }
+
+  .navNext {
+    right: max(var(--space-lg), env(safe-area-inset-right));
+  }
+
+  .navButton:active {
+    transform: translateY(-50%) scale(0.96);
   }
 }
 

--- a/src/components/app/Card.module.css
+++ b/src/components/app/Card.module.css
@@ -3,73 +3,9 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: var(--card-max-width);
-  margin: 0 auto;
+  height: 100%;
   background: var(--color-surface);
-  border-radius: var(--card-radius);
-  box-shadow: var(--card-shadow);
   overflow: hidden;
-  transition: box-shadow var(--transition-normal), transform var(--transition-normal);
-}
-
-/* ─── Fullscreen layouts ─────────────────────────────────────────── */
-/* Edge: true edge-to-edge, no card chrome. */
-.card.layoutEdge {
-  max-width: none;
-  height: 100%;
-  margin: 0;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-/* Padded: fills the screen but keeps card chrome and a margin. */
-.card.layoutPadded {
-  max-width: none;
-  height: 100%;
-  margin: 0;
-}
-
-/* In fullscreen layouts the image area grows to fill leftover space. */
-.card.layoutEdge .imageArea,
-.card.layoutPadded .imageArea {
-  flex: 1 1 auto;
-  height: auto;
-  min-height: 0;
-}
-
-/* Stretch the content area too — pad it generously so the word breathes. */
-.card.layoutEdge .content,
-.card.layoutPadded .content {
-  flex: 0 0 auto;
-  padding: var(--space-xl) var(--space-lg) var(--space-lg);
-  gap: var(--space-lg);
-}
-
-/* iPad portrait — emoji can be massive */
-@media (min-width: 768px) and (orientation: portrait) {
-  .card.layoutEdge .imageArea,
-  .card.layoutPadded .imageArea {
-    font-size: clamp(180px, 30vh, 320px);
-  }
-
-  .card.layoutEdge .imageLabel,
-  .card.layoutPadded .imageLabel {
-    font-size: 40px;
-  }
-
-  .card.layoutEdge .content,
-  .card.layoutPadded .content {
-    padding: var(--space-2xl) var(--space-xl) var(--space-xl);
-    gap: var(--space-xl);
-  }
-}
-
-/* Landscape — keep image generous, content compact */
-@media (min-width: 768px) and (orientation: landscape) {
-  .card.layoutEdge .imageArea,
-  .card.layoutPadded .imageArea {
-    font-size: clamp(120px, 22vh, 220px);
-  }
 }
 
 /* Cooldown — subtle, brief unresponsive state for toddler-mode taps. */
@@ -84,13 +20,13 @@
 /* ─── Image Area ─────────────────────────────────────────────────── */
 .imageArea {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: var(--space-sm);
-  height: 260px;
+  min-height: 0;
   background: var(--color-surface-sunken);
-  font-size: 110px;
   line-height: 1;
 }
 
@@ -106,9 +42,10 @@
 /* ─── Content Area ───────────────────────────────────────────────── */
 .content {
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   align-items: center;
-  padding: var(--space-xl) var(--space-md) var(--space-md);
+  padding: var(--space-xl) var(--space-lg) var(--space-lg);
   gap: var(--space-lg);
 }
 
@@ -253,13 +190,7 @@
 
 /* Phone */
 @media (max-width: 767px) {
-  .card {
-    border-radius: 20px;
-    margin: 0 var(--space-sm);
-  }
-
   .imageArea {
-    height: 200px;
     font-size: 80px;
   }
 
@@ -290,18 +221,8 @@
   }
 }
 
-/* Tablet portrait */
-@media (min-width: 768px) and (max-width: 1023px) {
-  .imageArea {
-    height: 300px;
-    font-size: 130px;
-  }
-
-  .content {
-    padding: var(--space-xl) var(--space-lg) var(--space-md);
-    gap: var(--space-xl);
-  }
-
+/* Tablet+ */
+@media (min-width: 768px) {
   .hearItButton {
     height: 64px;
     max-width: 340px;
@@ -313,38 +234,62 @@
   }
 }
 
-/* Tablet landscape / desktop */
-@media (min-width: 1024px) {
-  .imageArea {
-    height: 340px;
-    font-size: 150px;
-  }
-
-  .content {
-    padding: var(--space-xl) var(--space-xl) var(--space-md);
-    gap: var(--space-xl);
-  }
-
-  .hearItButton {
-    height: 64px;
-    max-width: 340px;
-    font-size: 20px;
-  }
-
-  .tipText {
-    font-size: 15px;
-  }
-}
-
-/* Large desktop */
-@media (min-width: 1200px) {
-  .card {
-    max-width: 700px;
-  }
-}
-
-/* iPad / large tablet portrait — bigger touch targets for toddler-friendly use */
+/* iPad / large tablet portrait — bigger emoji and label */
 @media (min-width: 768px) and (orientation: portrait) {
+  .imageArea {
+    font-size: clamp(180px, 30vh, 320px);
+  }
+
+  .imageLabel {
+    font-size: 40px;
+  }
+
+  .content {
+    padding: var(--space-2xl) var(--space-xl) var(--space-xl);
+  }
+}
+
+/* Tablet+ landscape — emoji clamp tuned for short viewport */
+@media (min-width: 768px) and (orientation: landscape) {
+  .imageArea {
+    font-size: clamp(120px, 22vh, 220px);
+  }
+}
+
+/* Short landscape (tablets rotated, laptops with low-res screens) — compact card chrome */
+@media (min-width: 768px) and (max-height: 900px) and (orientation: landscape) {
+  .imageArea {
+    font-size: 90px;
+  }
+
+  .imageLabel {
+    font-size: 22px;
+    margin-top: var(--space-xs);
+  }
+
+  .content {
+    padding: var(--space-md) var(--space-lg) var(--space-sm);
+    gap: var(--space-md);
+  }
+
+  .wordRow {
+    font-size: clamp(40px, 6vw, 64px);
+  }
+
+  .hearItButton {
+    height: 52px;
+    font-size: 18px;
+    max-width: 300px;
+  }
+
+  .tipText {
+    font-size: 14px;
+  }
+}
+
+/* iPad-class touch targets — large portrait or large landscape */
+@media (min-width: 768px) and (orientation: portrait),
+       (min-width: 1024px) and (orientation: landscape) {
   .content {
     gap: var(--space-2xl);
   }
@@ -374,78 +319,11 @@
     width: 30px;
     height: 30px;
   }
-
-  /* Side-pin nav buttons to viewport edges, like landscape. */
-  .actionBar {
-    height: 0;
-    padding: 0;
-    border-top: none;
-    overflow: visible;
-  }
-
-  .actionBarSpacer {
-    display: none;
-  }
-
-  .navButton {
-    position: fixed;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: var(--z-action-bar);
-  }
-
-  .navPrev {
-    left: max(var(--space-lg), env(safe-area-inset-left));
-  }
-
-  .navNext {
-    right: max(var(--space-lg), env(safe-area-inset-right));
-  }
-
-  .navButton:active {
-    transform: translateY(-50%) scale(0.96);
-  }
 }
 
-/* Short landscape (tablets rotated, laptops with low-res screens) — keep the card in view without page scroll */
-@media (min-width: 768px) and (max-height: 900px) and (orientation: landscape) {
-  .imageArea {
-    height: 200px;
-    font-size: 90px;
-  }
-
-  .imageLabel {
-    font-size: 22px;
-    margin-top: var(--space-xs);
-  }
-
-  .content {
-    padding: var(--space-md) var(--space-lg) var(--space-sm);
-    gap: var(--space-md);
-  }
-
-  .wordRow {
-    font-size: clamp(40px, 6vw, 64px);
-  }
-
-  .hearItButton {
-    height: 52px;
-    font-size: 18px;
-    max-width: 300px;
-  }
-
-  .tipText {
-    font-size: 14px;
-    min-height: calc(2 * 1.5 * 14px);
-  }
-
-  .actionBar {
-    padding-top: var(--space-xs);
-  }
-}
-
-/* Landscape — pin nav buttons to the viewport edges so they sit beside the card */
-@media (orientation: landscape) {
+/* Pin nav buttons to viewport edges — any landscape, plus large portrait */
+@media (orientation: landscape),
+       (min-width: 768px) and (orientation: portrait) {
   .actionBar {
     height: 0;
     padding: 0;
@@ -477,38 +355,9 @@
   }
 }
 
-/* iPad landscape — match the iPad portrait button size */
-@media (orientation: landscape) and (min-width: 1024px) {
-  .content {
-    gap: var(--space-2xl);
-  }
-
-  .hearItButton {
-    height: 84px;
-    max-width: 460px;
-    font-size: 22px;
-    border-radius: 20px;
-    margin-top: var(--space-md);
-  }
-
-  .hearItButton svg {
-    width: 26px;
-    height: 26px;
-  }
-
-  .navButton {
-    height: 88px;
-    padding: 0 32px;
-    font-size: 22px;
-    border-radius: 20px;
-    gap: var(--space-md);
-  }
-
-  .navButton svg {
-    width: 30px;
-    height: 30px;
-  }
-
+/* Wider edge insets where touch targets are big */
+@media (min-width: 768px) and (orientation: portrait),
+       (min-width: 1024px) and (orientation: landscape) {
   .navPrev {
     left: max(var(--space-lg), env(safe-area-inset-left));
   }

--- a/src/components/app/Card.module.css
+++ b/src/components/app/Card.module.css
@@ -12,6 +12,66 @@
   transition: box-shadow var(--transition-normal), transform var(--transition-normal);
 }
 
+/* ─── Fullscreen layouts ─────────────────────────────────────────── */
+/* Edge: true edge-to-edge, no card chrome. */
+.card.layoutEdge {
+  max-width: none;
+  height: 100%;
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* Padded: fills the screen but keeps card chrome and a margin. */
+.card.layoutPadded {
+  max-width: none;
+  height: 100%;
+  margin: 0;
+}
+
+/* In fullscreen layouts the image area grows to fill leftover space. */
+.card.layoutEdge .imageArea,
+.card.layoutPadded .imageArea {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
+}
+
+/* Stretch the content area too — pad it generously so the word breathes. */
+.card.layoutEdge .content,
+.card.layoutPadded .content {
+  flex: 0 0 auto;
+  padding: var(--space-xl) var(--space-lg) var(--space-lg);
+  gap: var(--space-lg);
+}
+
+/* iPad portrait — emoji can be massive */
+@media (min-width: 768px) and (orientation: portrait) {
+  .card.layoutEdge .imageArea,
+  .card.layoutPadded .imageArea {
+    font-size: clamp(180px, 30vh, 320px);
+  }
+
+  .card.layoutEdge .imageLabel,
+  .card.layoutPadded .imageLabel {
+    font-size: 40px;
+  }
+
+  .card.layoutEdge .content,
+  .card.layoutPadded .content {
+    padding: var(--space-2xl) var(--space-xl) var(--space-xl);
+    gap: var(--space-xl);
+  }
+}
+
+/* Landscape — keep image generous, content compact */
+@media (min-width: 768px) and (orientation: landscape) {
+  .card.layoutEdge .imageArea,
+  .card.layoutPadded .imageArea {
+    font-size: clamp(120px, 22vh, 220px);
+  }
+}
+
 /* Cooldown — subtle, brief unresponsive state for toddler-mode taps. */
 .cooldown .hearItButton,
 .cooldown .navButton,

--- a/src/components/app/Card.tsx
+++ b/src/components/app/Card.tsx
@@ -4,6 +4,8 @@ import { segmentWord } from '~/engine/wordSegmentation'
 import { emojiMap } from '~/data/emojiMap'
 import styles from './Card.module.css'
 
+export type CardLayout = 'classic' | 'edge' | 'padded'
+
 interface CardProps {
   card: ComputedWordCard
   onAudioPlay: (word: string) => void
@@ -11,6 +13,7 @@ interface CardProps {
   onPrev: () => void
   onNext: () => void
   cooldownActive?: boolean
+  layout?: CardLayout
 }
 
 function SpeakerIcon({ size = 16 }: { size?: number }) {
@@ -39,7 +42,13 @@ function ArrowIcon({ direction }: { direction: 'left' | 'right' }) {
   )
 }
 
-export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldownActive = false }: CardProps) {
+const LAYOUT_CLASSES: Record<CardLayout, string> = {
+  classic: '',
+  edge: styles.layoutEdge,
+  padded: styles.layoutPadded,
+}
+
+export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldownActive = false, layout = 'classic' }: CardProps) {
   const emoji = emojiMap[card.word.visual_hint] ?? '🔤'
 
   const segments = segmentWord(
@@ -51,7 +60,7 @@ export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldow
   const coachingTip = generateCoachingTip(card.word, card.drill_mode)
 
   return (
-    <div className={`${styles.card} ${cooldownActive ? styles.cooldown : ''}`}>
+    <div className={`${styles.card} ${LAYOUT_CLASSES[layout]} ${cooldownActive ? styles.cooldown : ''}`}>
       <div className={styles.imageArea}>
         <span className="emoji" role="img" aria-label={card.word.visual_hint}>
           {emoji}

--- a/src/components/app/Card.tsx
+++ b/src/components/app/Card.tsx
@@ -4,8 +4,6 @@ import { segmentWord } from '~/engine/wordSegmentation'
 import { emojiMap } from '~/data/emojiMap'
 import styles from './Card.module.css'
 
-export type CardLayout = 'classic' | 'edge' | 'padded'
-
 interface CardProps {
   card: ComputedWordCard
   onAudioPlay: (word: string) => void
@@ -13,7 +11,6 @@ interface CardProps {
   onPrev: () => void
   onNext: () => void
   cooldownActive?: boolean
-  layout?: CardLayout
 }
 
 function SpeakerIcon({ size = 16 }: { size?: number }) {
@@ -42,13 +39,7 @@ function ArrowIcon({ direction }: { direction: 'left' | 'right' }) {
   )
 }
 
-const LAYOUT_CLASSES: Record<CardLayout, string> = {
-  classic: '',
-  edge: styles.layoutEdge,
-  padded: styles.layoutPadded,
-}
-
-export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldownActive = false, layout = 'classic' }: CardProps) {
+export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldownActive = false }: CardProps) {
   const emoji = emojiMap[card.word.visual_hint] ?? '🔤'
 
   const segments = segmentWord(
@@ -60,7 +51,7 @@ export function Card({ card, onAudioPlay, onPhonemePlay, onPrev, onNext, cooldow
   const coachingTip = generateCoachingTip(card.word, card.drill_mode)
 
   return (
-    <div className={`${styles.card} ${LAYOUT_CLASSES[layout]} ${cooldownActive ? styles.cooldown : ''}`}>
+    <div className={`${styles.card} ${cooldownActive ? styles.cooldown : ''}`}>
       <div className={styles.imageArea}>
         <span className="emoji" role="img" aria-label={card.word.visual_hint}>
           {emoji}

--- a/src/components/app/FilterPanel.module.css
+++ b/src/components/app/FilterPanel.module.css
@@ -20,19 +20,19 @@
   bottom: 0;
   width: 300px;
   background: var(--color-surface);
-  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.12);
   z-index: calc(var(--z-overlay) + 1);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
   transform: translateX(-100%);
-  transition: transform var(--transition-normal);
+  transition: transform var(--transition-normal), box-shadow var(--transition-normal);
   font-family: var(--font-family);
 }
 
 .panelOpen {
   transform: translateX(0);
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.12);
 }
 
 /* ─── Header ──────────────────────────────────────────────────────── */

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -6,7 +6,7 @@ import { computeAgeMonths, formatAgeShort } from '~/engine/ageUtils'
 import { useCards } from '~/hooks/useCards'
 import { useAudio, usePrefetchAudio } from '~/hooks/useAudio'
 import { AgeEntry } from '~/components/app/AgeEntry'
-import { Card, type CardLayout } from '~/components/app/Card'
+import { Card } from '~/components/app/Card'
 import { FilterPanel } from '~/components/app/FilterPanel'
 import { UnlockModal } from '~/components/app/UnlockModal'
 import { WordSearch } from '~/components/app/WordSearch'
@@ -19,29 +19,6 @@ const STORAGE_KEY_BIRTH = 'phoneme-trainer-birth'
 const STORAGE_KEY_OVERRIDES = 'phoneme-trainer-overrides'
 const STORAGE_KEY_REACH = 'phoneme-trainer-reach'
 const STORAGE_KEY_TODDLER = 'phoneme-trainer-toddler-mode'
-const STORAGE_KEY_LAYOUT = 'phoneme-trainer-card-layout'
-
-const LAYOUT_CYCLE: CardLayout[] = ['edge', 'padded', 'classic']
-const LAYOUT_LABEL: Record<CardLayout, string> = {
-  edge: 'Edge',
-  padded: 'Padded',
-  classic: 'Card',
-}
-
-function loadLayout(): CardLayout {
-  if (typeof window === 'undefined') return 'edge'
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY_LAYOUT)
-    if (stored === 'edge' || stored === 'padded' || stored === 'classic') return stored
-    return 'edge'
-  } catch {
-    return 'edge'
-  }
-}
-
-function saveLayout(layout: CardLayout) {
-  localStorage.setItem(STORAGE_KEY_LAYOUT, layout)
-}
 
 interface BirthDate {
   month: number
@@ -125,7 +102,6 @@ function AppRoute() {
   const [pinnedCard, setPinnedCard] = useState<ComputedWordCard | null>(null)
   const [toddlerMode, setToddlerMode] = useState(false)
   const [unlockOpen, setUnlockOpen] = useState(false)
-  const [layout, setLayout] = useState<CardLayout>('edge')
   const [cooldownLocked, setCooldownLocked] = useState(false)
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -136,16 +112,6 @@ function AppRoute() {
     setSoundOverrides(loadOverrides())
     setReachMonths(loadReach())
     setToddlerMode(loadToddlerMode())
-    setLayout(loadLayout())
-  }, [])
-
-  const cycleLayout = useCallback(() => {
-    setLayout(prev => {
-      const idx = LAYOUT_CYCLE.indexOf(prev)
-      const next = LAYOUT_CYCLE[(idx + 1) % LAYOUT_CYCLE.length]
-      saveLayout(next)
-      return next
-    })
   }, [])
 
   const enableToddlerMode = useCallback(() => {
@@ -359,23 +325,6 @@ function AppRoute() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           {!toddlerMode && (
             <button
-              onClick={cycleLayout}
-              title={`Layout: ${LAYOUT_LABEL[layout]} — click to cycle`}
-              style={{
-                fontSize: '13px',
-                fontWeight: 700,
-                color: 'var(--color-text-muted)',
-                padding: '6px 10px',
-                borderRadius: '10px',
-                background: 'var(--color-surface-sunken)',
-              }}
-            >
-              {LAYOUT_LABEL[layout]}
-            </button>
-          )}
-
-          {!toddlerMode && (
-            <button
               onClick={() => setEditingAge(true)}
               style={{
                 fontSize: '13px',
@@ -436,15 +385,9 @@ function AppRoute() {
         style={{
           flex: 1,
           display: 'flex',
-          alignItems: layout === 'classic' ? 'center' : 'stretch',
+          alignItems: 'stretch',
           justifyContent: 'center',
           minHeight: 0,
-          padding:
-            layout === 'edge'
-              ? '0'
-              : layout === 'padded'
-              ? 'var(--space-md)'
-              : 'var(--space-sm) var(--space-md)',
         }}
       >
         {currentCard ? (
@@ -455,7 +398,6 @@ function AppRoute() {
             onPrev={guard(goPrev)}
             onNext={guard(goNext)}
             cooldownActive={cooldownActive}
-            layout={layout}
           />
         ) : (
           <div style={{ textAlign: 'center', color: 'var(--color-text-muted)' }}>

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -6,7 +6,7 @@ import { computeAgeMonths, formatAgeShort } from '~/engine/ageUtils'
 import { useCards } from '~/hooks/useCards'
 import { useAudio, usePrefetchAudio } from '~/hooks/useAudio'
 import { AgeEntry } from '~/components/app/AgeEntry'
-import { Card } from '~/components/app/Card'
+import { Card, type CardLayout } from '~/components/app/Card'
 import { FilterPanel } from '~/components/app/FilterPanel'
 import { UnlockModal } from '~/components/app/UnlockModal'
 import { WordSearch } from '~/components/app/WordSearch'
@@ -19,6 +19,29 @@ const STORAGE_KEY_BIRTH = 'phoneme-trainer-birth'
 const STORAGE_KEY_OVERRIDES = 'phoneme-trainer-overrides'
 const STORAGE_KEY_REACH = 'phoneme-trainer-reach'
 const STORAGE_KEY_TODDLER = 'phoneme-trainer-toddler-mode'
+const STORAGE_KEY_LAYOUT = 'phoneme-trainer-card-layout'
+
+const LAYOUT_CYCLE: CardLayout[] = ['edge', 'padded', 'classic']
+const LAYOUT_LABEL: Record<CardLayout, string> = {
+  edge: 'Edge',
+  padded: 'Padded',
+  classic: 'Card',
+}
+
+function loadLayout(): CardLayout {
+  if (typeof window === 'undefined') return 'edge'
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY_LAYOUT)
+    if (stored === 'edge' || stored === 'padded' || stored === 'classic') return stored
+    return 'edge'
+  } catch {
+    return 'edge'
+  }
+}
+
+function saveLayout(layout: CardLayout) {
+  localStorage.setItem(STORAGE_KEY_LAYOUT, layout)
+}
 
 interface BirthDate {
   month: number
@@ -102,6 +125,7 @@ function AppRoute() {
   const [pinnedCard, setPinnedCard] = useState<ComputedWordCard | null>(null)
   const [toddlerMode, setToddlerMode] = useState(false)
   const [unlockOpen, setUnlockOpen] = useState(false)
+  const [layout, setLayout] = useState<CardLayout>('edge')
   const [cooldownLocked, setCooldownLocked] = useState(false)
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -112,6 +136,16 @@ function AppRoute() {
     setSoundOverrides(loadOverrides())
     setReachMonths(loadReach())
     setToddlerMode(loadToddlerMode())
+    setLayout(loadLayout())
+  }, [])
+
+  const cycleLayout = useCallback(() => {
+    setLayout(prev => {
+      const idx = LAYOUT_CYCLE.indexOf(prev)
+      const next = LAYOUT_CYCLE[(idx + 1) % LAYOUT_CYCLE.length]
+      saveLayout(next)
+      return next
+    })
   }, [])
 
   const enableToddlerMode = useCallback(() => {
@@ -325,6 +359,23 @@ function AppRoute() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           {!toddlerMode && (
             <button
+              onClick={cycleLayout}
+              title={`Layout: ${LAYOUT_LABEL[layout]} — click to cycle`}
+              style={{
+                fontSize: '13px',
+                fontWeight: 700,
+                color: 'var(--color-text-muted)',
+                padding: '6px 10px',
+                borderRadius: '10px',
+                background: 'var(--color-surface-sunken)',
+              }}
+            >
+              {LAYOUT_LABEL[layout]}
+            </button>
+          )}
+
+          {!toddlerMode && (
+            <button
               onClick={() => setEditingAge(true)}
               style={{
                 fontSize: '13px',
@@ -385,9 +436,15 @@ function AppRoute() {
         style={{
           flex: 1,
           display: 'flex',
-          alignItems: 'center',
+          alignItems: layout === 'classic' ? 'center' : 'stretch',
           justifyContent: 'center',
-          padding: 'var(--space-sm) var(--space-md)',
+          minHeight: 0,
+          padding:
+            layout === 'edge'
+              ? '0'
+              : layout === 'padded'
+              ? 'var(--space-md)'
+              : 'var(--space-sm) var(--space-md)',
         }}
       >
         {currentCard ? (
@@ -398,6 +455,7 @@ function AppRoute() {
             onPrev={guard(goPrev)}
             onNext={guard(goNext)}
             cooldownActive={cooldownActive}
+            layout={layout}
           />
         ) : (
           <div style={{ textAlign: 'center', color: 'var(--color-text-muted)' }}>

--- a/src/server/submitWord.ts
+++ b/src/server/submitWord.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from '@tanstack/react-start'
-import { getRequestIP } from '@tanstack/react-start-server'
+import { getRequestIP } from '@tanstack/react-start/server'
 import { words } from '~/data/words'
 import { findLexicalMatch } from './lexicalDedup'
 


### PR DESCRIPTION
## Summary
- Word-practice card now supports three layouts: `classic` (current centered card), `edge` (true edge-to-edge fullscreen, no chrome), and `padded` (fullscreen with a margin and rounded corners).
- In fullscreen layouts, the image area is `flex: 1` so the emoji scales to use leftover vertical space. iPad portrait gets a generous `clamp(180px, 30vh, 320px)` emoji.
- Layout choice persists in `localStorage` and cycles via a small button in the header (`Edge / Padded / Card`). Defaults to `edge`.

Primary target is iPad Pro 11" (2019), portrait. Iterating on which variant feels best.

## Test plan
- [ ] On iPad Pro 11" portrait, `Edge` layout fills the viewport with no rounded corners, no shadow.
- [ ] `Padded` layout fills the viewport but keeps the card chrome and a small margin.
- [ ] `Card` (classic) restores the previous centered look.
- [ ] Cycle button in the header switches between layouts and the choice survives a reload.
- [ ] Phone portrait still renders sensibly (image area scales down, content fits).
- [ ] Landscape on tablet keeps the side-pinned prev/next nav buttons.
- [ ] Toddler mode hides the layout cycle button.