### PR TITLE
Tune PWA caching and preload current card audio

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,20 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/audio/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/icon-192.png
+  Cache-Control: public, max-age=2592000
+
+/icon-512.png
+  Cache-Control: public, max-age=2592000
+
+/icon.svg
+  Cache-Control: public, max-age=2592000
+
+/apple-touch-icon.png
+  Cache-Control: public, max-age=2592000
+
+/manifest.webmanifest
+  Cache-Control: public, max-age=3600

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -98,7 +98,7 @@ export function usePrefetchAudio(card: ComputedWordCard | undefined) {
     const links: HTMLLinkElement[] = []
     for (const href of urls) {
       const link = document.createElement('link')
-      link.rel = 'prefetch'
+      link.rel = 'preload'
       link.as = 'audio'
       link.href = href
       document.head.appendChild(link)


### PR DESCRIPTION
## Summary
- Add `public/_headers` for Cloudflare Workers Static Assets: `immutable` on hashed Vite output, `stale-while-revalidate` on `/audio/*` (stable URLs but content can be re-recorded), shorter max-ages for icons and manifest.
- Switch `usePrefetchAudio` from `rel=prefetch` to `rel=preload` so the current card's word + phoneme audio fetch at high priority instead of browser-idle.

## Context
PWA cold-start on iPad Pro 11 (2019) felt slow. Without a service worker, every cold start re-fetches the shell, so the win is at the HTTP layer: long-lived caches on hashed assets and audio that survive across visits, plus a higher-priority hint for the audio the user is about to tap.

bfcache audit was clean (no `unload` listeners, no `no-store`, no IndexedDB/WebSocket), so iOS standalone-PWA "switch away and back" should already restore from bfcache.

A separate follow-up will set `Cache-Control: no-cache` and `Link: rel=preload` headers on the SSR HTML response — needs a TanStack Start middleware which I want to verify against current docs first.

## Test plan
- [x] Deploy to Cloudflare and verify `Cache-Control: public, max-age=31536000, immutable` on `/assets/*-[hash].js|css`.
- [ ] Verify `Cache-Control: public, max-age=86400, stale-while-revalidate=604800` on `/audio/words/*.mp3`.
- [x] On the word practice page in Safari devtools, confirm `<link rel="preload" as="audio">` is present in `<head>` for the current card and that the audio request fires immediately on card change.
- [x] On iPad Pro 11 standalone PWA, observe whether warm cold-start (force-close + reopen) feels faster after a deploy + initial visit.