### PR TITLE
Preserve space between words in segmented display

### DIFF
--- a/src/components/app/Card.module.css
+++ b/src/components/app/Card.module.css
@@ -69,6 +69,7 @@
   position: relative;
   padding: 0 1px;
   border-radius: 6px;
+  white-space: pre;
   transition: background var(--transition-fast), transform var(--transition-fast);
 }
 


### PR DESCRIPTION
## Summary
- Multi-word entries like "how many" were rendering as "HOWMANY" — no gap between words.
- Each letter group renders as its own flex item; browsers collapse trailing whitespace inside flex items, so the space the segmenter emitted as part of the surrounding vowel segment disappeared.
- Added `white-space: pre` to `.letterGroup` so the space is preserved. Fix applies to every multi-word entry ("ice cream", "thank you", "garbage truck", etc.).

## Test plan
- [ ] Open card 168/379 ("how many"); confirm the segmented display reads "HOW MANY" with a visible gap.
- [ ] Spot-check another multi-word card (e.g., "ice cream", "thank you") — gap should also render.
- [ ] Single-word cards unchanged.
- [ ] Tapping individual phonemes still triggers playback.